### PR TITLE
Bump 1.1.10-beta.3

### DIFF
--- a/artifacts/index.ts
+++ b/artifacts/index.ts
@@ -8,6 +8,7 @@ export { EMAOracle } from './ts/EMAOracle';
 export { FeedFactory } from './ts/FeedFactory';
 export { HistoricalPriceFeed } from './ts/HistoricalPriceFeed';
 export { InverseMACOStrategyManager } from './ts/InverseMACOStrategyManager';
+export { LastValueOracle } from './ts/LastValueOracle';
 export { LegacyMakerOracleAdapter } from './ts/LegacyMakerOracleAdapter';
 export { LinearizedEMATimeSeriesFeed } from './ts/LinearizedEMATimeSeriesFeed';
 export { LinearizedPriceDataSource } from './ts/LinearizedPriceDataSource';
@@ -37,6 +38,7 @@ export {
 	FeedFactoryContract,
 	HistoricalPriceFeedContract,
 	InverseMACOStrategyManagerContract,
+	LastValueOracleContract,
 	LegacyMakerOracleAdapterContract,
 	LinkedListLibraryMockContract,
 	LinearizedEMATimeSeriesFeedContract,
@@ -53,4 +55,5 @@ export {
 	RSIOracleContract,
 	RSITrendingTriggerContract,
 	TimeSeriesFeedContract,
+	TwoAssetLinearizedTimeSeriesFeedContract,
 } from "../utils/contracts";

--- a/artifacts/index.ts
+++ b/artifacts/index.ts
@@ -24,6 +24,7 @@ export { PriceFeed } from './ts/PriceFeed';
 export { RSIOracle } from './ts/RSIOracle';
 export { RSITrendingTrigger } from './ts/RSITrendingTrigger';
 export { TimeSeriesFeed } from './ts/TimeSeriesFeed';
+export { TwoAssetLinearizedTimeSeriesFeed } from './ts/TwoAssetLinearizedTimeSeriesFeed';
 
 // Export abi-gen contract wrappers
 export {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "set-protocol-strategies",
-  "version": "1.1.10-beta.2",
+  "version": "1.1.10-beta.3",
   "main": "dist/artifacts/index.js",
   "typings": "dist/typings/artifacts/index.d.ts",
   "files": [


### PR DESCRIPTION
Exports `LastValueOracle` and `TwoAssetLinearizedTimeSeriesFeedContract`