### PR TITLE
Bump contracts version and change path imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "set-protocol-strategies",
-  "version": "1.1.34",
+  "version": "1.1.35",
   "main": "dist/artifacts/index.js",
   "typings": "dist/typings/artifacts/index.d.ts",
   "files": [
@@ -102,7 +102,7 @@
     "minify-all": "^1.2.2",
     "module-alias": "^2.1.0",
     "openzeppelin-solidity": "^2.2",
-    "set-protocol-contracts": "^1.3.55-beta",
+    "set-protocol-contracts": "^1.4.0-beta",
     "set-protocol-oracles": "^1.0.15",
     "set-protocol-utils": "^1.1.2",
     "tiny-promisify": "^1.0.0",

--- a/test/contracts/managers/allocators/binaryAllocator.spec.ts
+++ b/test/contracts/managers/allocators/binaryAllocator.spec.ts
@@ -13,7 +13,6 @@ import { BigNumberSetup } from '@utils/bigNumberSetup';
 import { Blockchain } from 'set-protocol-contracts';
 import { ether } from '@utils/units';
 import {
-  Core,
   CoreContract,
   SetTokenContract,
   SetTokenFactoryContract,
@@ -50,6 +49,8 @@ import { ERC20Helper } from '@utils/helpers/erc20Helper';
 import { ManagerHelper } from '@utils/helpers/managerHelper';
 import { OracleHelper } from 'set-protocol-oracles';
 import { ProtocolHelper } from '@utils/helpers/protocolHelper';
+
+const Core = require('set-protocol-contracts/dist/artifacts/ts/Core').Core;
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/contracts/managers/allocators/socialAllocator.spec.ts
+++ b/test/contracts/managers/allocators/socialAllocator.spec.ts
@@ -13,7 +13,6 @@ import { BigNumberSetup } from '@utils/bigNumberSetup';
 import { Blockchain } from 'set-protocol-contracts';
 import { ether } from '@utils/units';
 import {
-  Core,
   CoreContract,
   OracleWhiteListContract,
   SetTokenFactoryContract,
@@ -48,6 +47,8 @@ import { OracleHelper } from 'set-protocol-oracles';
 import { ERC20Helper } from '@utils/helpers/erc20Helper';
 import { ManagerHelper } from '@utils/helpers/managerHelper';
 import { ProtocolHelper } from '@utils/helpers/protocolHelper';
+
+const Core = require('set-protocol-contracts/dist/artifacts/ts/Core').Core;
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/contracts/managers/assetPairManager.spec.ts
+++ b/test/contracts/managers/assetPairManager.spec.ts
@@ -13,7 +13,6 @@ import { BigNumberSetup } from '@utils/bigNumberSetup';
 import { Blockchain } from 'set-protocol-contracts';
 import { ether } from '@utils/units';
 import {
-  Core,
   CoreContract,
   LinearAuctionPriceCurveContract,
   RebalancingSetTokenContract,
@@ -49,6 +48,8 @@ import { getWeb3, blankTxn } from '@utils/web3Helper';
 import { ERC20Helper } from '@utils/helpers/erc20Helper';
 import { ManagerHelper } from '@utils/helpers/managerHelper';
 import { ProtocolHelper } from '@utils/helpers/protocolHelper';
+
+const Core = require('set-protocol-contracts/dist/artifacts/ts/Core').Core;
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/contracts/managers/btcDaiRebalancingManager.spec.ts
+++ b/test/contracts/managers/btcDaiRebalancingManager.spec.ts
@@ -10,12 +10,10 @@ import { BigNumber } from 'bignumber.js';
 import ChaiSetup from '@utils/chaiSetup';
 import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
-  Core,
   CoreContract,
   LinearAuctionPriceCurveContract,
   SetTokenContract,
   RebalanceAuctionModuleContract,
-  RebalancingSetToken,
   RebalancingSetTokenContract,
   RebalancingSetTokenFactoryContract,
   SetTokenFactoryContract,
@@ -42,6 +40,9 @@ import { ProtocolHelper } from '@utils/helpers/protocolHelper';
 import { ERC20Helper } from '@utils/helpers/erc20Helper';
 import { OracleHelper } from 'set-protocol-oracles';
 import { ManagerHelper } from '@utils/helpers/managerHelper';
+
+const Core = require('set-protocol-contracts/dist/artifacts/ts/Core').Core;
+const RebalancingSetToken = require('set-protocol-contracts/dist/artifacts/ts/RebalancingSetToken').RebalancingSetToken;
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/contracts/managers/btcEthRebalancingManager.spec.ts
+++ b/test/contracts/managers/btcEthRebalancingManager.spec.ts
@@ -10,7 +10,6 @@ import { BigNumber } from 'bignumber.js';
 import ChaiSetup from '@utils/chaiSetup';
 import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
-  Core,
   CoreContract,
   LinearAuctionPriceCurveContract,
   SetTokenContract,
@@ -44,6 +43,8 @@ import { ProtocolHelper } from '@utils/helpers/protocolHelper';
 import { ERC20Helper } from '@utils/helpers/erc20Helper';
 import { OracleHelper } from 'set-protocol-oracles';
 import { ManagerHelper } from '@utils/helpers/managerHelper';
+
+const Core = require('set-protocol-contracts/dist/artifacts/ts/Core').Core;
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/contracts/managers/ethDaiRebalancingManager.spec.ts
+++ b/test/contracts/managers/ethDaiRebalancingManager.spec.ts
@@ -10,11 +10,9 @@ import { BigNumber } from 'bignumber.js';
 import ChaiSetup from '@utils/chaiSetup';
 import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
-  Core,
   CoreContract,
   LinearAuctionPriceCurveContract,
   RebalanceAuctionModuleContract,
-  RebalancingSetToken,
   RebalancingSetTokenContract,
   RebalancingSetTokenFactoryContract,
   SetTokenContract,
@@ -42,6 +40,9 @@ import { ProtocolHelper } from '@utils/helpers/protocolHelper';
 import { ERC20Helper } from '@utils/helpers/erc20Helper';
 import { OracleHelper } from 'set-protocol-oracles';
 import { ManagerHelper } from '@utils/helpers/managerHelper';
+
+const Core = require('set-protocol-contracts/dist/artifacts/ts/Core').Core;
+const RebalancingSetToken = require('set-protocol-contracts/dist/artifacts/ts/RebalancingSetToken').RebalancingSetToken;
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/contracts/managers/inverseMacoStrategyManager.spec.ts
+++ b/test/contracts/managers/inverseMacoStrategyManager.spec.ts
@@ -13,7 +13,6 @@ import { BigNumberSetup } from '@utils/bigNumberSetup';
 import { Blockchain } from 'set-protocol-contracts';
 import { ether } from '@utils/units';
 import {
-  Core,
   CoreContract,
   LinearAuctionPriceCurveContract,
   RebalancingSetTokenContract,
@@ -54,6 +53,8 @@ import { ERC20Helper } from '@utils/helpers/erc20Helper';
 import { ManagerHelper } from '@utils/helpers/managerHelper';
 import { OracleHelper } from 'set-protocol-oracles';
 import { ProtocolHelper } from '@utils/helpers/protocolHelper';
+
+const Core = require('set-protocol-contracts/dist/artifacts/ts/Core').Core;
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/contracts/managers/macoStrategyManager.spec.ts
+++ b/test/contracts/managers/macoStrategyManager.spec.ts
@@ -13,7 +13,6 @@ import { BigNumberSetup } from '@utils/bigNumberSetup';
 import { Blockchain } from 'set-protocol-contracts';
 import { ether } from '@utils/units';
 import {
-  Core,
   CoreContract,
   LinearAuctionPriceCurveContract,
   RebalancingSetTokenContract,
@@ -51,6 +50,8 @@ import { ERC20Helper } from '@utils/helpers/erc20Helper';
 import { ManagerHelper } from '@utils/helpers/managerHelper';
 import { OracleHelper } from 'set-protocol-oracles';
 import { ProtocolHelper } from '@utils/helpers/protocolHelper';
+
+const Core = require('set-protocol-contracts/dist/artifacts/ts/Core').Core;
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/contracts/managers/macoStrategyManagerV2.spec.ts
+++ b/test/contracts/managers/macoStrategyManagerV2.spec.ts
@@ -13,7 +13,6 @@ import { BigNumberSetup } from '@utils/bigNumberSetup';
 import { Blockchain } from 'set-protocol-contracts';
 import { ether } from '@utils/units';
 import {
-  Core,
   CoreContract,
   LinearAuctionPriceCurveContract,
   RebalancingSetTokenContract,
@@ -54,6 +53,8 @@ import { ERC20Helper } from '@utils/helpers/erc20Helper';
 import { ManagerHelper } from '@utils/helpers/managerHelper';
 import { OracleHelper } from 'set-protocol-oracles';
 import { ProtocolHelper } from '@utils/helpers/protocolHelper';
+
+const Core = require('set-protocol-contracts/dist/artifacts/ts/Core').Core;
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/contracts/managers/socialTradingManager.spec.ts
+++ b/test/contracts/managers/socialTradingManager.spec.ts
@@ -13,7 +13,6 @@ import { BigNumberSetup } from '@utils/bigNumberSetup';
 import { Blockchain } from 'set-protocol-contracts';
 import { ether } from '@utils/units';
 import {
-  Core,
   CoreContract,
   FixedFeeCalculatorContract,
   LinearAuctionLiquidatorContract,
@@ -65,6 +64,8 @@ import { OracleHelper } from 'set-protocol-oracles';
 import { ERC20Helper } from '@utils/helpers/erc20Helper';
 import { ManagerHelper } from '@utils/helpers/managerHelper';
 import { ProtocolHelper } from '@utils/helpers/protocolHelper';
+
+const Core = require('set-protocol-contracts/dist/artifacts/ts/Core').Core;
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/contracts/managers/socialTradingManagerV2.spec.ts
+++ b/test/contracts/managers/socialTradingManagerV2.spec.ts
@@ -13,7 +13,6 @@ import { BigNumberSetup } from '@utils/bigNumberSetup';
 import { Blockchain } from 'set-protocol-contracts';
 import { ether } from '@utils/units';
 import {
-  Core,
   CoreContract,
   LinearAuctionLiquidatorContract,
   OracleWhiteListContract,
@@ -60,6 +59,8 @@ import { OracleHelper } from 'set-protocol-oracles';
 import { ERC20Helper } from '@utils/helpers/erc20Helper';
 import { ManagerHelper } from '@utils/helpers/managerHelper';
 import { ProtocolHelper } from '@utils/helpers/protocolHelper';
+
+const Core = require('set-protocol-contracts/dist/artifacts/ts/Core').Core;
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/integrations/assetPairManager.spec.ts
+++ b/test/integrations/assetPairManager.spec.ts
@@ -13,7 +13,6 @@ import { BigNumberSetup } from '@utils/bigNumberSetup';
 import { Blockchain } from 'set-protocol-contracts';
 import { ether } from '@utils/units';
 import {
-  Core,
   CoreContract,
   LinearAuctionPriceCurveContract,
   RebalancingSetTokenContract,
@@ -24,6 +23,7 @@ import {
   WethMockContract,
   WhiteListContract,
 } from 'set-protocol-contracts';
+
 import {
   ConstantPriceOracleContract,
   EMAOracleContract,
@@ -59,6 +59,8 @@ import { ERC20Helper } from '@utils/helpers/erc20Helper';
 import { ManagerHelper } from '@utils/helpers/managerHelper';
 import { OracleHelper } from 'set-protocol-oracles';
 import { ProtocolHelper } from '@utils/helpers/protocolHelper';
+
+const Core = require('set-protocol-contracts/dist/artifacts/ts/Core').Core;
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/scenarios/btc-eth/btcEthMultipleRebalance.spec.ts
+++ b/test/scenarios/btc-eth/btcEthMultipleRebalance.spec.ts
@@ -4,11 +4,6 @@ import * as chai from 'chai';
 import * as _ from 'lodash';
 import * as ABIDecoder from 'abi-decoder';
 import { BigNumber } from 'set-protocol-utils';
-import {
-  Core,
-  RebalancingSetToken,
-  RebalanceAuctionModule,
-} from 'set-protocol-contracts';
 
 import ChaiSetup from '@utils/chaiSetup';
 import { BigNumberSetup } from '@utils/bigNumberSetup';
@@ -23,6 +18,12 @@ import {
 } from './types';
 
 import { BTCETHMultipleRebalanceHelper } from './btcEthMultipleRebalanceHelper';
+
+const Core = require('set-protocol-contracts/dist/artifacts/ts/Core').Core;
+const RebalanceAuctionModule =
+  require('set-protocol-contracts/dist/artifacts/ts/RebalanceAuctionModule').RebalanceAuctionModule;
+const RebalancingSetToken =
+  require('set-protocol-contracts/dist/artifacts/ts/RebalancingSetToken').RebalancingSetToken;
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/test/scenarios/btc-eth/btcEthRebalancing.spec.ts
+++ b/test/scenarios/btc-eth/btcEthRebalancing.spec.ts
@@ -10,12 +10,9 @@ import { SetProtocolTestUtils, Web3Utils } from 'set-protocol-utils';
 import ChaiSetup from '@utils/chaiSetup';
 import { BigNumberSetup } from '@utils/bigNumberSetup';
 import {
-  Core,
   CoreContract,
   LinearAuctionPriceCurveContract,
-  RebalanceAuctionModule,
   RebalanceAuctionModuleContract,
-  RebalancingSetToken,
   RebalancingSetTokenContract,
   RebalancingSetTokenFactoryContract,
   SetTokenContract,
@@ -25,6 +22,10 @@ import {
   VaultContract,
   WethMockContract,
 } from 'set-protocol-contracts';
+import { Core } from 'set-protocol-contracts/dist/artifacts/ts/Core';
+import { RebalanceAuctionModule } from 'set-protocol-contracts/dist/artifacts/ts/RebalanceAuctionModule';
+import { RebalancingSetToken } from 'set-protocol-contracts/dist/artifacts/ts/RebalancingSetToken';
+
 import {
   MedianContract,
 } from 'set-protocol-oracles';

--- a/test/scenarios/maco-strategy/macoManagerMultipleRebalance.spec.ts
+++ b/test/scenarios/maco-strategy/macoManagerMultipleRebalance.spec.ts
@@ -4,11 +4,6 @@ import * as chai from 'chai';
 import * as _ from 'lodash';
 import * as ABIDecoder from 'abi-decoder';
 import { BigNumber } from 'set-protocol-utils';
-import {
-  Core,
-  RebalancingSetToken,
-  RebalanceAuctionModule,
-} from 'set-protocol-contracts';
 
 import ChaiSetup from '@utils/chaiSetup';
 import { BigNumberSetup } from '@utils/bigNumberSetup';
@@ -23,6 +18,12 @@ import {
 } from './types';
 
 import { MACOStrategyMultipleRebalanceHelper } from './macoStrategyMultipleRebalanceHelper';
+
+const Core = require('set-protocol-contracts/dist/artifacts/ts/Core').Core;
+const RebalanceAuctionModule =
+  require('set-protocol-contracts/dist/artifacts/ts/RebalanceAuctionModule').RebalanceAuctionModule;
+const RebalancingSetToken =
+  require('set-protocol-contracts/dist/artifacts/ts/RebalancingSetToken').RebalancingSetToken;
 
 BigNumberSetup.configure();
 ChaiSetup.configure();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,13 +8,14 @@
     "baseUrl": ".",
     "moduleResolution": "node",
     "paths": {
-    "@deployments/*": [ "deployments/*" ],
-    "@utils/*": [ "utils/*" ]
+      "@deployments/*": [ "deployments/*" ],
+      "@utils/*": [ "utils/*" ]
     },
     "rootDir": ".",
     "target": "es5",
     "allowJs": true,
     "typeRoots": [
+      "node_modules/set-protocol-contracts/dist/typings/artifacts/ts",
       "node_modules/@0xproject/types",
       "node_modules/set-protocol-utils/types",
       "node_modules/@types"

--- a/utils/helpers/protocolHelper.ts
+++ b/utils/helpers/protocolHelper.ts
@@ -3,29 +3,41 @@ import * as setProtocolUtils from 'set-protocol-utils';
 import { Address } from 'set-protocol-utils';
 
 import {
-  Core,
   CoreContract,
-  LinearAuctionPriceCurve,
   LinearAuctionPriceCurveContract,
-  RebalanceAuctionModule,
   RebalanceAuctionModuleContract,
   RebalancingSetTokenContract,
-  RebalancingSetTokenV2,
   RebalancingSetTokenV2Contract,
-  RebalancingSetTokenFactory,
   RebalancingSetTokenFactoryContract,
-  SetToken,
   SetTokenContract,
-  SetTokenFactory,
   SetTokenFactoryContract,
   StandardTokenMockContract,
-  TransferProxy,
   TransferProxyContract,
-  Vault,
   VaultContract,
   WethMockContract,
   WhiteListContract,
 } from 'set-protocol-contracts';
+const Core = require('set-protocol-contracts/dist/artifacts/ts/Core').Core;
+const LinearAuctionPriceCurve =
+  require(
+    'set-protocol-contracts/dist/artifacts/ts/LinearAuctionPriceCurve'
+  ).LinearAuctionPriceCurve;
+const RebalanceAuctionModule =
+  require('set-protocol-contracts/dist/artifacts/ts/RebalanceAuctionModule').RebalanceAuctionModule;
+const RebalancingSetTokenV2 =
+  require('set-protocol-contracts/dist/artifacts/ts/RebalancingSetTokenV2').RebalancingSetTokenV2;
+const RebalancingSetTokenFactory =
+  require(
+    'set-protocol-contracts/dist/artifacts/ts/RebalancingSetTokenFactory'
+  ).RebalancingSetTokenFactory;
+const SetToken = require('set-protocol-contracts/dist/artifacts/ts/SetToken').SetToken;
+const SetTokenFactory =
+  require('set-protocol-contracts/dist/artifacts/ts/SetTokenFactory').SetTokenFactory;
+const TransferProxy =
+  require('set-protocol-contracts/dist/artifacts/ts/TransferProxy').TransferProxy;
+const Vault =
+  require('set-protocol-contracts/dist/artifacts/ts/Vault').Vault;
+
 import {
   MedianContract
 } from 'set-protocol-oracles';

--- a/utils/web3Helper.ts
+++ b/utils/web3Helper.ts
@@ -64,7 +64,8 @@ export const importFromContracts = (contractName: string) => {
 };
 
 const importFromRepo = (repoName: string, contractName: string) => {
-  const data = require(repoName)[contractName];
+  const data = require(repoName + '/dist/artifacts/ts/' + contractName)[contractName];
+
   const instance = contract(data);
   instance.setProvider(web3.currentProvider);
   return instance;
@@ -80,7 +81,7 @@ export const importArtifactsFromSource = (contractName: string) => {
   } catch (e) {}
 
   try {
-    const data = require('set-protocol-strategies/dist/artifacts/ts/' + contractName + '.js')[contractName];
+    const data = require('set-protocol-strategies/dist/artifacts/ts/' + contractName)[contractName];
     instance = contract(data);
     instance.setProvider(web3.currentProvider);
 
@@ -88,7 +89,7 @@ export const importArtifactsFromSource = (contractName: string) => {
   } catch (e) {}
 
   try {
-    const filePath = 'set-protocol-strategies-' + version + '/dist/artifacts/ts/' + contractName + '.js';
+    const filePath = 'set-protocol-strategies-' + version + '/dist/artifacts/ts/' + contractName;
     const data = require(filePath)[contractName];
     instance = contract(data);
     instance.setProvider(web3.currentProvider);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6668,10 +6668,10 @@ set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
-set-protocol-contracts@^1.3.55-beta:
-  version "1.3.55-beta"
-  resolved "https://registry.yarnpkg.com/set-protocol-contracts/-/set-protocol-contracts-1.3.55-beta.tgz#8bc25960b9118c32206afc60314bc02d0fa518b0"
-  integrity sha512-BpGN+B+zG61UYeEC+Iz6orz3BDpQd+LVbhWPla7ChOwMbk0kyzMkAVMNUmvrTKsgPI/o81wTbQ7FAUGtUj13zQ==
+set-protocol-contracts@^1.4.0-beta:
+  version "1.4.0-beta"
+  resolved "https://registry.yarnpkg.com/set-protocol-contracts/-/set-protocol-contracts-1.4.0-beta.tgz#b7f482dfaba596c180b4efb2a51aafee02f56082"
+  integrity sha512-zYczLu+8JA4zhvWK6LyzyVx58navvAxF9WcBEhQI2Tpt7DLdkzs2Chy/3iFjjFbn7u+Ar1NJe6yEmLSbDUgMXQ==
   dependencies:
     bn-chai "^1.0.1"
     canonical-weth "^1.3.1"


### PR DESCRIPTION
To support changes in 1.4.0-beta of set-protocol-contracts, need to change import paths